### PR TITLE
decorate_chunk unnecessary line removal

### DIFF
--- a/R/decorate_chunk.R
+++ b/R/decorate_chunk.R
@@ -117,8 +117,6 @@ decorate_chunk <- function(chunk_name,
     # convert knitted string to a list with sources separate from output
     knitted <- knitted %>% src_to_list()
 
-    where_sources <-  map(knitted, ~attr(.x, "class")) == "source"
-
     attr(knitted, "class") <- "with_flair"
 
     attr(knitted, "orig_code_text") <- my_code


### PR DESCRIPTION
Line 120 made the variable where_sources which isn't used as far as I can tell (looks like that functionality is in the print functions now).